### PR TITLE
[BE] feat: 프로메테우스가 메트릭을 가져오는 API 호출 경로는 필터링 되지 않도록 설정

### DIFF
--- a/BackEnd/SpringBootServer/src/main/java/com/ssafy/backend/global/component/jwt/security/JwtTokenSecurityFilter.java
+++ b/BackEnd/SpringBootServer/src/main/java/com/ssafy/backend/global/component/jwt/security/JwtTokenSecurityFilter.java
@@ -125,4 +125,21 @@ public class JwtTokenSecurityFilter extends OncePerRequestFilter {
         writer.write(objectMapper.writeValueAsString(Message.fail(e.getErrorCode().name(), e.getMessage())));
         writer.flush();
     }
+
+    /**
+     * 특정 경로에 대해 JWT 필터를 적용하지 않도록 설정합니다.
+     * 이 메서드를 오버라이드하여 특정 조건에 해당하는 요청을 필터링하지 않도록 할 수 있습니다.
+     *
+     * @param request 현재 처리 중인 HTTP 요청 객체
+     * @return {@code true}이면 필터가 적용되지 않으며, {@code false}이면 필터가 적용됩니다.
+     *         여기서는 "/actuator/prometheus" 경로에 대해 필터를 건너뛰도록 설정했습니다.
+     * @throws ServletException 서블릿 예외 발생 시
+     */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException{
+        // 특정 경로에 대해 필터를 건너뜁니다.
+        // 프로메테우스가 메트릭을 가져오는 API 호출 경로는 필터링 되지 않으며, 해당 경로는 doFilterInternal() 로직을 타지 않습니다.
+        String requestURI = request.getRequestURI();
+        return "/actuator/prometheus".equals(requestURI);
+    }
 }


### PR DESCRIPTION
## 📝작업 내용

- 프로메테우스가 메트릭을 가져오는 API 호출 경로(/actuator/prometheus)는 필터링 되지 않도록 JWT 커스텀 필터를 재설정하였습니다.

## 타입

- [x] feat: 새로운 기능 추가
- [x] fix: 버그 수정
- [ ] chore: 빌드 업무 수정, 패키지 매니저 수정
- [ ] refactor: 코드 리펙토링
- [ ] style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] docs: 문서 수정
- [ ] test: 테스트 코드, 리펙토링 테스트 코드 추가

## MR하기 전에 확인해주세요
- [x] 코딩 컨벤션 지키셨나요?
- [x] loca ci test를 진행하셨나요 ?
- [x] 팀원들에게 공지하셨나요?

## 연관된 이슈