### PR TITLE
[FE] fix: Certbot이 Nginx SSL 자동 갱신 할 수 있도록 도커 실행 권한 추가

### DIFF
--- a/FrontEnd/docker-compose-frontend.yml
+++ b/FrontEnd/docker-compose-frontend.yml
@@ -30,6 +30,7 @@ services:
     volumes:
       - ./certbot/conf:/etc/letsencrypt # Certbot이 사용하는 SSL 인증서 경로입니다.
       - ./certbot/www:/var/www/certbot # Certbot의 인증 경로를 설정합니다.
+      - /var/run/docker.sock:/var/run/docker.sock # Docker 실행 권한을 추가합니다. (해당 Nginx 도커 컨테이너 SSL 자동 갱신을 위해)
     entrypoint: '/bin/sh -c ''trap exit TERM; while :; do certbot renew --quiet --no-self-upgrade --deploy-hook "docker exec nowdoboss-frontend nginx -s reload"; sleep 12h & wait $${!}; done;''' # Certbot이 인증서를 갱신한 후 Nginx를 자동으로 리로드합니다.
     depends_on:
       - nowdoboss_frontend_service # Nginx가 실행된 후 Certbot이 동작하도록 의존성을 설정합니다.


### PR DESCRIPTION
## 📝작업 내용

- Certbot이 Nginx SSL 자동 갱신 할 수 있도록 도커 실행 권한 추가하였습니다.

## 타입

- [ ] feat: 새로운 기능 추가
- [x] fix: 버그 수정
- [ ] chore: 빌드 업무 수정, 패키지 매니저 수정
- [ ] refactor: 코드 리펙토링
- [ ] style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] docs: 문서 수정
- [ ] test: 테스트 코드, 리펙토링 테스트 코드 추가

## MR하기 전에 확인해주세요
- [x] 코딩 컨벤션 지키셨나요?
- [x] loca ci test를 진행하셨나요 ?
- [x] 팀원들에게 공지하셨나요?

## 연관된 이슈